### PR TITLE
Field context

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ import DynamicFieldBuilder from 'rolling-fields';
   <DynamicFieldBuilder
     fields={} // Array of field objects
     mappings={} // Optional object to define how to render different types of fields
+    fieldContext={} // Optional value that will be shared among all fields when using custom mappping
     onBlur={}
     onChange={}
     setFieldValue={} // Use for custom input that does not support HTML SyntheticEvent
@@ -67,17 +68,35 @@ If no custom mappings are supplied, [default mappings](https://github.com/tes/ro
    const fields = [
       { name: 'green field' },
       { name: 'open field', type: 'custom' },
+      { name: 'hide', type: 'invisible', },
+      { name: 'show' type: 'visible', },
       { type: 'submit', text: 'Just do it!' },
     ];
     
     const mappings = {
-      string: ({ name }) => (<input name={name} className="string-field" />),
-      custom: ({ name }) => (<MyCustomComponent name={name} />),
-      submit: ({ name, text }) => (<button type="submit" >{text}</button>),
+      string: ({ name }) => (
+        <input name={name} className="string-field" />
+      ),
+      custom: ({ name }) => (
+        <MyCustomComponent name={name} />
+      ),
+      invisible: ({ name }, fieldContext) => !fieldContext.isVisible && (
+        <input name={name} />
+      ),
+      visible: ({ name }, fieldContext) => fieldContext.isVisible && (
+        <input name={name} />
+      ),
+      submit: ({ name, text }) => (
+        <button type="submit" >{text}</button>
+      ),
     };
     
   <form>
-    <DynamicFieldBuilder fields={fields} mappings={mappings} />
+    <DynamicFieldBuilder
+        fields={fields}
+        mappings={mappings}
+        fieldContext={{ isVisible: true }}
+        />
   </form>
 ```
 
@@ -87,6 +106,7 @@ If no custom mappings are supplied, [default mappings](https://github.com/tes/ro
  <form>
   <input name="green field" class="string-field" />
   <input name="open field" class="custom"> Something cool! </input>
+  <input name="show" />
   <button type="submit">Just do it!</button>
  </form>
  ``` 

--- a/lib/generateMappings.jsx
+++ b/lib/generateMappings.jsx
@@ -11,17 +11,17 @@ const generateMappings = ({
   onBlur,
   setFieldValue,
   field,
-}) => {
-  if (mappings.default && typeof mappings.default === 'function') {
-    return mappings[type]
-      ? mappings[type]({
-        index, key, onChange, onBlur, setFieldValue, ...field,
-      })
-      : mappings.default({
-        index, key, onChange, onBlur, setFieldValue, ...field,
-      });
+}, fieldContext) => {
+  if (!mappings.default || typeof mappings.default !== 'function') {
+    return <input name={name} key={key} onChange={onChange} onBlur={onBlur} />;
   }
-  return <input name={name} key={key} onChange={onChange} onBlur={onBlur} />;
+  return mappings[type]
+    ? mappings[type]({
+      index, key, onChange, onBlur, setFieldValue, ...field,
+    }, fieldContext)
+    : mappings.default({
+      index, key, onChange, onBlur, setFieldValue, ...field,
+    });
 };
 
 export default generateMappings;

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -14,7 +14,7 @@ const getProp = (object, keys, defaultVal) => {
 /* eslint-enable no-param-reassign */
 
 export default function DynamicFieldBuilder({
-  fields, mappings: customMappings, onChange, onBlur, setFieldValue, initialValues,
+  fields, mappings: customMappings, fieldContext, onChange, onBlur, setFieldValue, initialValues,
 }) {
   const mappings = { ...defaultMappings, ...customMappings };
   return (fields.map((field, index) => {
@@ -34,7 +34,7 @@ export default function DynamicFieldBuilder({
       field: fieldWithValue || field,
       value,
     };
-    return generateMappings({ ...mappingVariables });
+    return generateMappings({ ...mappingVariables }, fieldContext);
   })
   );
 }

--- a/test/unit/rolling-fields.test.jsx
+++ b/test/unit/rolling-fields.test.jsx
@@ -231,6 +231,29 @@ describe('Rolling fields', () => {
     assert.equal(input.getElements()[2].props.value, 'Final value');
   });
 
+  it('will use the provided field context when mapping components', () => {
+    const placeHolderText = 'Place me in my holder!';
+
+    const fields = [
+      { name: 'test', type: 'custom' },
+    ];
+    const mappings = {
+      custom: ({ key, name }, fieldContext) => (
+        <input key={key} name={name} placeholder={fieldContext.placeHolderText} />
+      ),
+    };
+    const wrapper = mount(
+      <RollingFields
+        fields={fields}
+        mappings={mappings}
+        fieldContext={{ placeHolderText }}
+      />,
+    );
+    const inputs = wrapper.find('input');
+    assert.equal(inputs.length, 1);
+    assert.deepEqual(inputs.at(0).props(), { name: 'test', placeholder: placeHolderText });
+  });
+
   it('will call the provided setFieldValue function', () => {
     const fields = [
       { name: 'test', type: 'custom' },


### PR DESCRIPTION
Adds the ability to pass a top level value to all fields for use when customMapping.

Useful for a case like in AMUI, where we have some top level state which we want to use to simultaneously update all fields, without having to pass it individually to each one.