### PR TITLE
Add error support as a separated property

### DIFF
--- a/lib/MapField.jsx
+++ b/lib/MapField.jsx
@@ -16,6 +16,7 @@ class MapField extends PureComponent {
       defaultValue,
       field,
       fieldContext,
+      error,
     } = this.props;
 
     if (!mappings.default || typeof mappings.default !== 'function') {
@@ -31,6 +32,7 @@ class MapField extends PureComponent {
         onChange,
         onBlur,
         setFieldValue,
+        error,
         ...field,
       }, fieldContext)
       : mappings.default({
@@ -41,6 +43,7 @@ class MapField extends PureComponent {
         onChange,
         onBlur,
         setFieldValue,
+        error,
         ...field,
       }, fieldContext);
   }

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -63,7 +63,7 @@ DynamicFieldBuilder.propTypes = {
   setFieldValue: PropTypes.func,
   initialValues: PropTypes.shape(),
   values: PropTypes.shape(),
-  errors: PropTypes.oneOf([PropTypes.object, PropTypes.string]),
+  errors: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 };
 
 DynamicFieldBuilder.defaultProps = {

--- a/lib/index.jsx
+++ b/lib/index.jsx
@@ -24,10 +24,12 @@ const DynamicFieldBuilder = ({
   initialValues,
   values,
   customShouldComponentUpdate,
+  errors,
 }) => {
   const mappings = { ...defaultMappings, ...customMappings };
   return (fields.map((field, index) => {
     const { name, type } = field;
+    const error = errors && getProp(errors, name);
     const value = values && getProp(values, name, '');
     const defaultValue = initialValues && getProp(initialValues, name, '');
     const id = (`${name}${index}`).replace(/\s/g, '');
@@ -45,6 +47,7 @@ const DynamicFieldBuilder = ({
       defaultValue,
       field,
       customShouldComponentUpdate,
+      error,
     };
     return <MapFieldWrapper {...mappingProps} fieldContext={fieldContext} />;
   })
@@ -60,6 +63,7 @@ DynamicFieldBuilder.propTypes = {
   setFieldValue: PropTypes.func,
   initialValues: PropTypes.shape(),
   values: PropTypes.shape(),
+  errors: PropTypes.oneOf([PropTypes.object, PropTypes.string]),
 };
 
 DynamicFieldBuilder.defaultProps = {

--- a/test/unit/rolling-fields.test.jsx
+++ b/test/unit/rolling-fields.test.jsx
@@ -554,4 +554,47 @@ describe('Rolling fields', () => {
     assert.include(wrapper.children().at(1).html(), 'value="THIS SHOULD CHANGE"');
     assert.include(wrapper.children().at(2).html(), 'value="Should not update"');
   });
+
+  it('will give the mappings function access to the error of the field', () => {
+    const fields = [
+      { name: 'test1', type: 'custom' },
+    ];
+    const mappings = {
+      custom: ({ key, name }) => (
+        <input key={key} name={name} />
+      ),
+    };
+    const errors = {
+      test1: 'test1 is required',
+      test2: 'test2 is required',
+    };
+    const customComponentSpy = spy(mappings, 'custom');
+    mount(
+      <RollingFields fields={fields} mappings={mappings} errors={errors} />,
+    );
+
+    assert.equal(customComponentSpy.calledOnce, true);
+    assert.equal(customComponentSpy.getCall(0).args[0].error, errors.test1);
+  });
+
+  it('will not give the mappings function access to the error of other field', () => {
+    const fields = [
+      { name: 'test1', type: 'custom' },
+    ];
+    const mappings = {
+      custom: ({ key, name }) => (
+        <input key={key} name={name} />
+      ),
+    };
+    const errors = {
+      test2: 'test2 is required',
+    };
+    const customComponentSpy = spy(mappings, 'custom');
+    mount(
+      <RollingFields fields={fields} mappings={mappings} errors={errors} />,
+    );
+
+    assert.equal(customComponentSpy.calledOnce, true);
+    assert.isUndefined(customComponentSpy.getCall(0).args[0].error);
+  });
 });


### PR DESCRIPTION
Closes #11 

This PR implements a way to easily add error state to a form created with rolling fields